### PR TITLE
Seed canvas with story/task dataset

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,7 +674,69 @@
     if (!links.some(l => l.from === fromId && l.to === toId)) addLink(fromId, toId);
   }
 
-  // Seed example nodes for testing without touching saved state
+  
+  const SEED_DATA=[
+    { id:100, title:'Nimbus Deployment Workflow', tasks:[
+      {id:1, status:'🟢', title:'Adjust Apache proxy settings', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:'2025-07-15 18:12'},
+      {id:2, status:'🟢', title:'Create read-only deploy key', state:'Completed', estimate:'', comment:'', created:'', started:'2025-07-15 09:30', completed:'2025-07-15 12:40'},
+      {id:20, status:'🟢', title:'Validate hybrid deployment pipeline', state:'Completed', estimate:'', comment:'Work log 09:15–11:15; 13:00–15:00; 16:00–18:45', created:'2025-07-15 12:40', started:'2025-07-16 09:15', completed:'2025-07-16 18:45'},
+      {id:27, status:'🟢', title:'Finalize service-host pipelines', state:'Completed', estimate:'', comment:'', created:'2025-07-16 18:45', started:'2025-07-17 14:00', completed:'2025-07-17 16:20'},
+      {id:28, status:'🔵', title:'Craft proxy automation workflow', state:'In progress', estimate:'', comment:'', created:'2025-07-16 18:45', started:'', completed:''},
+      {id:29, status:'🔵', title:'Run CI workflow tests', state:'In progress', estimate:'', comment:'', created:'2025-07-16 18:45', started:'2025-07-17 16:50', completed:''},
+      {id:25, status:'🟢', title:'GitHub onboarding workshop', state:'Completed', estimate:'', comment:'Session with teammate', created:'2025-07-16 11:00', started:'2025-07-16 11:00', completed:'2025-07-16 12:15'},
+      {id:30, status:'🟢', title:'Investigate DDH bug', state:'Completed', estimate:'', comment:'', created:'2025-07-16 18:45', started:'2025-07-17 10:05', completed:'2025-07-17 10:22'},
+      {id:32, status:'🟢', title:'Backlog refinement meeting', state:'Completed', estimate:'', comment:'', created:'2025-07-17 08:20', started:'2025-07-17 08:20', completed:'2025-07-17 09:40'}
+    ]},
+    { id:101, title:'Metrics Dashboard Access', tasks:[
+      {id:3, status:'🟢', title:'File ticket for dashboard access', state:'Completed', estimate:'', comment:'waiting for approval', created:'2025-07-15 10:11', started:'', completed:'2025-07-15 10:32'},
+      {id:4, status:'🟢', title:'Give Alex administrator role', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:'2025-07-15 10:45'},
+      {id:5, status:'🟢', title:'Verify Jordan dashboard access', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:'2025-07-16 14:18'}
+    ]},
+    { id:102, title:'Misc Engineering Tasks', tasks:[
+      {id:6, status:'🟢', title:'Check VM access for Alex', state:'Completed', estimate:'', comment:'', created:'2025-07-15 10:11', started:'2025-07-15 10:20', completed:'2025-07-15 10:40'},
+      {id:7, status:'🔵', title:'Inspect OpenTelemetry gateway', state:'In progress', estimate:'', comment:'', created:'2025-07-15 10:25', started:'', completed:''},
+      {id:8, status:'🟢', title:'Break', state:'Completed', estimate:'', comment:'12:30–13:10 → 40m; 14:00–14:05 → 5m; 17:00–17:12 → 12m; 17:20–18:50 → 90m; total 147m', created:'2025-07-15 12:15', started:'2025-07-15 12:15', completed:'2025-07-16 18:50'},
+      {id:9, status:'🟢', title:'Prepare handover notes', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:''},
+      {id:10, status:'🟢', title:'Discuss observability tooling', state:'Completed', estimate:'', comment:'Call with team lead', created:'2025-07-15 13:20', started:'2025-07-15 13:20', completed:'2025-07-15 15:55'},
+      {id:21, status:'⚪', title:'Update time sheet', state:'Not started', estimate:'', comment:'', created:'2025-07-15 16:45', started:'', completed:''},
+      {id:31, status:'🟢', title:'Pair-program on Otel collector', state:'Completed', estimate:'', comment:'', created:'2025-07-17 13:10', started:'2025-07-17 13:10', completed:'2025-07-17 14:40'}
+    ]},
+    { id:103, title:'Personal Errands', tasks:[
+      {id:11, status:'⚪', title:'Plan weekend trip with family', state:'Not started', estimate:'', comment:'', created:'', started:'', completed:''},
+      {id:12, status:'⚪', title:'Review mod list for Stardew', state:'Not started', estimate:'', comment:'', created:'', started:'', completed:''},
+      {id:13, status:'🟢', title:'Ping family about status', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:'2025-07-16 14:12'},
+      {id:14, status:'🟢', title:'Reply to friend', state:'Completed', estimate:'', comment:'20:40–20:45', created:'', started:'', completed:'2025-07-15 20:45'},
+      {id:15, status:'🟢', title:'Send voice note to Sam', state:'Completed', estimate:'', comment:'', created:'', started:'2025-07-16 14:12', completed:'2025-07-16 14:12'},
+      {id:16, status:'🟢', title:'Share birthday photos with Ella', state:'Completed', estimate:'', comment:'', created:'2025-07-15 11:40', started:'2025-07-17 12:10', completed:'2025-07-17 12:25'},
+      {id:17, status:'⚪', title:'Call back Tim', state:'Not started', estimate:'', comment:'', created:'2025-07-15 11:40', started:'', completed:''},
+      {id:18, status:'🟢', title:'Reply to Aria on chat', state:'Completed', estimate:'1', comment:'', created:'2025-07-15 12:40', started:'', completed:'2025-07-15 20:32'},
+      {id:19, status:'🟢', title:'Send message to Arturo', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:''},
+      {id:26, status:'🟢', title:'Hang laundry', state:'Completed', estimate:'', comment:'', created:'2025-07-16 18:45', started:'2025-07-16 19:05', completed:'2025-07-16 19:20'}
+    ]},
+    { id:104, title:'Home Chores', tasks:[
+      {id:22, status:'🔵', title:'Water plants', state:'In progress', estimate:'1', comment:'20:50–21:00', created:'2025-07-15 20:40', started:'2025-07-15 20:40', completed:'2025-07-15 21:00'},
+      {id:23, status:'🟢', title:'Wash dishes', state:'Completed', estimate:'1', comment:'20:40–21:10', created:'2025-07-15 20:40', started:'2025-07-15 20:40', completed:'2025-07-15 21:10'},
+      {id:24, status:'🟢', title:'Tidy apartment', state:'Completed', estimate:'1', comment:'20:40–21:10', created:'2025-07-15 20:40', started:'2025-07-15 20:40', completed:'2025-07-15 21:10'}
+    ]}
+  ];
+
+
+  function seedFromData(data){
+    data.forEach((story,si)=>{
+      const sx=60+si*260, sy=60;
+      let sid=findNodeByTitle(story.title);
+      if(sid==null) sid=createNode({id:story.id, title:story.title, x:sx, y:sy});
+      story.tasks.forEach((t,ti)=>{
+        const desc=`- **Status:** ${t.status}\n- **State:** ${t.state}\n- **Estimate:** ${t.estimate}\n- **Comment:** ${t.comment}\n- **CreatedAt:** ${t.created}\n- **StartedAt:** ${t.started}\n- **CompletedAt:** ${t.completed}`;
+        const tx=sx, ty=sy+100*(ti+1);
+        let tid=findNodeByTitle(t.title);
+        if(tid==null) tid=createNode({id:t.id, title:t.title, x:tx, y:ty, desc});
+        ensureLink(sid, tid);
+      });
+    });
+  }
+
+  // Seed full task dataset without touching saved state
   function seedCanvas(){
     const prev = localStorage.getItem(STORAGE_KEY);
     const semPrev = localStorage.getItem(SEM_CACHE_KEY);
@@ -686,15 +748,10 @@
     saveAll = () => {}; // suppress writes during seeding
 
     try {
-      const idA = findNodeByTitle('Example A') ?? createNode({title:'Example A', x:80,  y:80});
-      const idB = findNodeByTitle('Example B') ?? createNode({title:'Example B', x:280, y:160});
-      const idC = findNodeByTitle('Example C') ?? createNode({title:'Example C', x:480, y:80});
-
-      ensureLink(idA, idB);
-      ensureLink(idB, idC);
+      seedFromData(SEED_DATA);
 
       applyViewModeToAll?.();
-      logAction?.('Seeded sample graph (Example A → Example B → Example C)');
+      logAction?.('Seeded sample task dataset');
     } finally {
       saveAll = savedSaveAll;
       suppressSaves = prevSuppress;
@@ -709,55 +766,7 @@
 
   // Bootstrap
   function bootstrap(){ const s=loadAll(); if(s && s.nodes){ const ids=Object.keys(s.nodes).map(Number).sort((a,b)=>a-b); ids.forEach(id=>{ const n=s.nodes[id]; createNode({id:n.id, title:n.title, x:n.x, y:n.y, desc:n.desc, descOpen:n.descOpen}); }); nextId = Math.max(s.nextId||1, Math.max(0,...ids)+1); if (Array.isArray(s.links)) s.links.forEach(([f,t])=>addLink(f,t)); applyViewModeToAll(); logAction('Restored from localStorage'); } else {
-    const data=[
-      { id:100, title:'AKM Hybrid Deployments', tasks:[
-        {id:1, status:'🟢', title:'Update Nginx configuration for Edvin', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:'2025-08-26 21:07'},
-        {id:2, status:'🟢', title:'Implement read-only deploy key for AKM repository', state:'Completed', estimate:'', comment:'', created:'', started:'2025-08-26 13:30', completed:'2025-08-26 17:05'},
-        {id:20, status:'🟢', title:'Review Changes and Test Hybrid Deployments', state:'Completed', estimate:'', comment:'Progress 10:30–12:30; 13:45–15:30; 15:30–22:51', created:'2025-08-26 17:05', started:'2025-08-27 10:30', completed:'2025-08-27 22:51'},
-        {id:27, status:'🟢', title:'Finalize akm-service-host workflows', state:'Completed', estimate:'', comment:'', created:'2025-08-27 22:51', started:'2025-08-28 15:15', completed:'2025-08-28 18:30'},
-        {id:28, status:'🔵', title:'Implement akm-proxy workflow', state:'In progress', estimate:'', comment:'', created:'2025-08-27 22:51', started:'', completed:''},
-        {id:29, status:'🔵', title:'Test GitHub workflows', state:'In progress', estimate:'', comment:'', created:'2025-08-27 22:51', started:'2025-08-28 17:45', completed:''},
-        {id:25, status:'🟢', title:'GitHub Introduction Workshop with Manfred', state:'Completed', estimate:'', comment:'GitHub Workshop Call with Philip', created:'2025-08-27 12:30', started:'2025-08-27 12:30', completed:'2025-08-27 13:45'},
-        {id:30, status:'🟢', title:'Ask Angelo about DDH issue', state:'Completed', estimate:'', comment:'', created:'2025-08-27 22:51', started:'2025-08-28 11:30', completed:'2025-08-28 11:45'},
-        {id:32, status:'🟢', title:'ODO Board Grooming', state:'Completed', estimate:'', comment:'', created:'2025-08-28 10:00', started:'2025-08-28 10:00', completed:'2025-08-28 11:30'}
-      ]},
-      { id:101, title:'Grafana Access Permissions', tasks:[
-        {id:3, status:'🟢', title:'Send ticket to APA IT for Grafana access', state:'Completed', estimate:'', comment:'waiting for Amadeus', created:'2025-08-26 11:59', started:'', completed:'2025-08-26 12:20'},
-        {id:4, status:'🟢', title:'Grant Philip administrator role in Grafana', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:'2025-08-26 12:30'},
-        {id:5, status:'🟢', title:'Verify Amadeus Grafana access', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:'2025-08-27 15:40'}
-      ]},
-      { id:102, title:'Other Work Tasks', tasks:[
-        {id:6, status:'🟢', title:'Check VM Access for Philip', state:'Completed', estimate:'', comment:'', created:'2025-08-26 11:59', started:'2025-08-26 12:10', completed:'2025-08-26 12:30'},
-        {id:7, status:'🔵', title:'Check OpenTelemetry Gateway', state:'In progress', estimate:'', comment:'', created:'2025-08-26 12:05', started:'', completed:''},
-        {id:8, status:'🟢', title:'Break', state:'Completed', estimate:'', comment:'12:30–13:20 → 50m; 13:40–13:45 → 5m; 17:05–17:15 → 10m; 17:20–19:20 → 120m; total 185m', created:'2025-08-26 12:30', started:'2025-08-26 12:30', completed:'2025-08-27 19:20'},
-        {id:9, status:'🟢', title:'Prepare AIKM Handover', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:''},
-        {id:10, status:'🟢', title:'Observability for Audio Tool', state:'Completed', estimate:'', comment:'Call with Martin Schatzl', created:'2025-08-26 13:45', started:'2025-08-26 13:45', completed:'2025-08-26 16:24'},
-        {id:21, status:'⚪', title:'Update Time Sheet', state:'Not started', estimate:'', comment:'', created:'2025-08-26 17:05', started:'', completed:''},
-        {id:31, status:'🟢', title:'Pair programming with Philipp for OtelCol AKM', state:'Completed', estimate:'', comment:'', created:'2025-08-28 13:45', started:'2025-08-28 13:45', completed:'2025-08-28 15:15'}
-      ]},
-      { id:103, title:'Personal Tasks', tasks:[
-        {id:11, status:'⚪', title:'Plan vacation with my mom', state:'Not started', estimate:'', comment:'', created:'', started:'', completed:''},
-        {id:12, status:'⚪', title:'Check RimWorld mod list', state:'Not started', estimate:'', comment:'', created:'', started:'', completed:''},
-        {id:13, status:'🟢', title:'Contact Mom and update status', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:'2025-08-27 15:40'},
-        {id:14, status:'🟢', title:'Reply to Jammin', state:'Completed', estimate:'', comment:'20:52–20:57', created:'', started:'', completed:'2025-08-26 20:57'},
-        {id:15, status:'🟢', title:'Send voicemail to Mary', state:'Completed', estimate:'', comment:'', created:'', started:'2025-08-27 15:40', completed:'2025-08-27 15:40'},
-        {id:16, status:'🟢', title:'Share birthday photos with Ellen', state:'Completed', estimate:'', comment:'', created:'2025-08-26 12:20', started:'2025-08-28 12:30', completed:'2025-08-28 12:45'},
-        {id:17, status:'⚪', title:'Reply to Tim (call yesterday)', state:'Not started', estimate:'', comment:'', created:'2025-08-26 12:20', started:'', completed:''},
-        {id:18, status:'🟢', title:'Reply to Armin in MS Teams', state:'Completed', estimate:'1', comment:'', created:'2025-08-26 13:20', started:'', completed:'2025-08-26 20:56'},
-        {id:19, status:'🟢', title:'Send message to Artur', state:'Completed', estimate:'', comment:'', created:'', started:'', completed:''},
-        {id:26, status:'🟢', title:'Wäsche aufhängen', state:'Completed', estimate:'', comment:'', created:'2025-08-27 22:51', started:'2025-08-27 23:15', completed:'2025-08-27 23:30'}
-      ]},
-      { id:104, title:'Housekeeping (Chores)', tasks:[
-        {id:22, status:'🔵', title:'Blumengießen', state:'In progress', estimate:'1', comment:'20:57–21:07', created:'2025-08-26 20:56', started:'2025-08-26 20:56', completed:'2025-08-26 21:07'},
-        {id:23, status:'🟢', title:'Geschirr waschen', state:'Completed', estimate:'1', comment:'20:56–21:16', created:'2025-08-26 20:56', started:'2025-08-26 20:56', completed:'2025-08-26 21:16'},
-        {id:24, status:'🟢', title:'Wohnung aufräumen', state:'Completed', estimate:'1', comment:'20:56–21:16', created:'2025-08-26 20:56', started:'2025-08-26 20:56', completed:'2025-08-26 21:16'}
-      ]}
-    ];
-
-    data.forEach((story,si)=>{
-      const sx=60+si*260, sy=60; createNode({id:story.id, title:story.title, x:sx, y:sy});
-      story.tasks.forEach((t,ti)=>{ const desc=`- **Status:** ${t.status}\n- **State:** ${t.state}\n- **Estimate:** ${t.estimate}\n- **Comment:** ${t.comment}\n- **CreatedAt:** ${t.created}\n- **StartedAt:** ${t.started}\n- **CompletedAt:** ${t.completed}`; const tx=sx, ty=sy+100*(ti+1); createNode({id:t.id, title:t.title, x:tx, y:ty, desc}); addLink(story.id, t.id); });
-    });
+    seedFromData(SEED_DATA);
 
     applyViewModeToAll(); saveAll();
   } }


### PR DESCRIPTION
## Summary
- seed canvas using full task table instead of placeholder nodes
- generate markdown descriptions and link tasks to their stories
- share seeding data for bootstrap and seeding operations
- anonymize task and story titles, comments and timestamps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a0c9f8f8832a8ee83fa788efa494