### PR TITLE
feat: modernize node styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Lightweight task graph editor: drag nodes, link/unlink tasks, write Markdown des
 * Drag-and-drop nodes with live link re-routing
 * Link and unlink mode (with context menu and long‑press on touch)
 * Inline title rename; bold task titles
+* Modern card-style nodes with color accents for quick visual scanning
 * Per-task description with Markdown preview (global Edit/Preview toggle)
 * Autosave to `localStorage` (positions, titles, descriptions, link graph, expanded state)
 * Dark/light theme toggle with persistence

--- a/index.html
+++ b/index.html
@@ -59,10 +59,12 @@
   line[data-link] { stroke: var(--link); stroke-width: 2.2; }
 
   /* Node */
-  .node { position: absolute; min-width: 180px; max-width: 360px; border: 1px solid var(--node-border); border-radius: 10px; background: var(--node-bg); box-shadow: 0 2px 14px rgba(20,32,75,0.06); user-select: none; touch-action: none; }
+  .node { position: absolute; min-width: 180px; max-width: 360px; border: 1px solid var(--node-border); border-radius: 12px; background: var(--node-bg); box-shadow: 0 2px 14px rgba(20,32,75,0.06); user-select: none; touch-action: none; transition: box-shadow .2s, transform .2s; }
+  .node:hover { transform: translateY(-2px); box-shadow: var(--shadow); }
   .node.selected { outline: 2px solid var(--accent-2); }
-  .node-header { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 8px; padding: 8px 10px; }
-  .node-title { font-weight: 700; line-height: 1.2; padding: 4px; border-radius: 6px; }
+  .node-header { display: flex; align-items: center; gap: 8px; padding: 10px; }
+  .node-color { width: 10px; height: 10px; border-radius: 50%; background: var(--node-border); flex-shrink: 0; }
+  .node-title { flex: 1; font-weight: 700; line-height: 1.2; padding: 4px; border-radius: 6px; }
   .node-title-input { width: 100%; border: 1px solid var(--node-border); background: var(--panel); color: var(--text); font: inherit; padding: 6px 8px; border-radius: 8px; box-sizing: border-box; }
   .toggle-desc { border: none; background: transparent; cursor: pointer; font-size: 14px; padding: 4px 6px; border-radius: 6px; }
   .toggle-desc:focus { outline: 2px solid var(--accent-2); }
@@ -325,9 +327,10 @@
     el.style.left=(typeof x==='number'?x:40*useId)+'px'; el.style.top=(typeof y==='number'?y:40*useId)+'px';
 
     const header=document.createElement('div'); header.className='node-header';
+    const colorDot=document.createElement('span'); colorDot.className='node-color';
     const titleEl=document.createElement('div'); titleEl.className='node-title'; titleEl.textContent=title||('Task '+useId);
     const toggle=document.createElement('button'); toggle.className='toggle-desc'; toggle.title='Toggle description'; toggle.textContent=descOpen?'▾':'▸';
-    header.appendChild(titleEl); header.appendChild(toggle);
+    header.appendChild(colorDot); header.appendChild(titleEl); header.appendChild(toggle);
 
     const descWrap=document.createElement('div'); descWrap.className='node-desc'; if(descOpen) descWrap.classList.add('open');
     const ta=document.createElement('textarea'); ta.placeholder='Markdown description…'; ta.value=desc||'';
@@ -337,7 +340,7 @@
     el.appendChild(header); el.appendChild(descWrap);
     nodesLayer.appendChild(el);
 
-    nodes.set(useId,{ el, titleEl, toggleEl:toggle, descWrap, ta, previewEl:preview });
+    nodes.set(useId,{ el, titleEl, toggleEl:toggle, descWrap, ta, previewEl:preview, colorEl:colorDot });
 
     // Select node on press
     el.addEventListener('pointerdown',()=>{ selectedId=useId; nodes.forEach(n=>n.el.classList.remove('selected')); el.classList.add('selected'); });
@@ -408,7 +411,7 @@
   function scheduleRecompute(){ if(recomputeTimer) clearTimeout(recomputeTimer); recomputeTimer=setTimeout(recomputeDirty,400); }
   function recomputeDirty(){ const ids=Array.from(dirtyNodes); dirtyNodes.clear(); computeEmbeddingsFor(ids); }
 
-  function clearSemanticColors(){ nodes.forEach(n=>{ n.el.style.borderColor='var(--node-border)'; n.el.style.boxShadow=''; }); }
+  function clearSemanticColors(){ nodes.forEach(n=>{ n.el.style.borderColor='var(--node-border)'; n.el.style.boxShadow=''; n.colorEl.style.background=''; }); }
   function vecToColor(v){
     const h = Math.round(v[0]*360);
     const s = Math.round(40 + v[1]*40);
@@ -423,6 +426,7 @@
   function applyColorToNode(n,color){
     n.el.style.borderColor = color;
     n.el.style.boxShadow   = `0 0 0 3px ${withAlpha(color, 0.25)}`;
+    n.colorEl.style.background = color;
   }
   function applySemanticColors(){ nodes.forEach((n,id)=>{ const c=semanticCache[id]; if(c) applyColorToNode(n,c.color); }); }
 

--- a/test-semantic-units.js
+++ b/test-semantic-units.js
@@ -15,7 +15,8 @@ const mockDOM = {
         id,
         titleEl: { textContent: title },
         ta: { value: content },
-        style: {}
+        style: {},
+        colorEl: { style: {} }
     }),
     
     // Mock functions from main app
@@ -33,6 +34,7 @@ const mockDOM = {
     
     applyColorToNode: (node, color) => {
         node.style.borderColor = color;
+        node.colorEl.style.background = color;
         return true;
     },
     


### PR DESCRIPTION
## Summary
- refresh node cards with hover lift and rounded edges
- add color accent dot to node headers
- update semantic coloring to tint the accent dot

## Testing
- `npm test`
- `node test-semantic-units.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0f5a60e1c832a89fc3075a82a8f52